### PR TITLE
add some more tests, use pytest instead of unittest.TestCase

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,8 +13,7 @@ before_install:
   - pip install -U pip
 
 install:
-  - pip install -U .[reco]
-  - pip install strict-rfc3339 jsonschema coveralls
+  - make installcheck
 
 script: coverage run --source marshmallow_jsonschema -m py.test
 after_success: coveralls

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,8 @@
+
+
+installcheck:
+	pip install -U .[reco]
+	pip install strict-rfc3339 jsonschema coveralls
+
+check:
+	py.test -v

--- a/setup.py
+++ b/setup.py
@@ -22,8 +22,8 @@ setup(
     packages=find_packages(exclude=("test*", )),
     package_dir={'marshmallow-jsonschema': 'marshmallow-jsonschema'},
     include_package_data=True,
-    install_requires=['marshmallow>=2.3.0'],
-    tests_require=['pytest>=2.1', 'jsonschema', 'strict-rfc3339'],
+    install_requires=['marshmallow>=2.9.0'],
+    tests_require=['pytest>=2.9.2', 'jsonschema', 'strict-rfc3339', 'coverage>=4.1'],
     license=read('LICENSE'),
     zip_safe=False,
     keywords=('marshmallow-jsonschema marshmallow schema serialization '

--- a/tests/test_dump.py
+++ b/tests/test_dump.py
@@ -1,119 +1,177 @@
-from marshmallow import Schema, fields
+from marshmallow import Schema, fields, validate
 from marshmallow_jsonschema import JSONSchema
 from jsonschema import Draft4Validator
+import pytest
 
 from . import BaseTest, UserSchema, Address
 
 
-class TestDumpSchema(BaseTest):
+def _validate_schema(schema):
+    '''
+    raises jsonschema.exceptions.SchemaError
+    '''
+    Draft4Validator.check_schema(schema)
 
-    def _validate_schema(self, schema):
-        '''
-        raises jsonschema.exceptions.SchemaError
-        '''
-        Draft4Validator.check_schema(schema)
+def test_dump_schema():
+    schema = UserSchema()
+    json_schema = JSONSchema()
+    dumped = json_schema.dump(schema).data
+    _validate_schema(dumped)
+    assert len(schema.fields) > 1
+    for field_name, field in schema.fields.items():
+        assert field_name in dumped['properties']
 
-    def test_dump_schema(self):
-        schema = UserSchema()
-        json_schema = JSONSchema()
-        dumped = json_schema.dump(schema).data
-        self._validate_schema(dumped)
-        self.assertGreater(len(schema.fields), 1)
-        for field_name, field in schema.fields.items():
-            self.assertIn(field_name, dumped['properties'])
+def test_default():
+    schema = UserSchema()
+    json_schema = JSONSchema()
+    dumped = json_schema.dump(schema).data
+    _validate_schema(dumped)
+    assert dumped['properties']['id']['default'] == 'no-id'
 
-    def test_default(self):
-        schema = UserSchema()
-        json_schema = JSONSchema()
-        dumped = json_schema.dump(schema).data
-        self._validate_schema(dumped)
-        self.assertEqual(dumped['properties']['id']['default'], 'no-id')
+def test_descriptions():
+    class TestSchema(Schema):
+        myfield = fields.String(metadata={'description': 'Brown Cow'})
+        yourfield = fields.Integer(required=True)
+    schema = TestSchema()
+    json_schema = JSONSchema()
+    dumped = json_schema.dump(schema).data
+    _validate_schema(dumped)
+    assert dumped['properties']['myfield']['description'] == 'Brown Cow'
 
-    def test_descriptions(self):
-        class TestSchema(Schema):
-            myfield = fields.String(metadata={'description': 'Brown Cow'})
-            yourfield = fields.Integer(required=True)
-        schema = TestSchema()
-        json_schema = JSONSchema()
-        dumped = json_schema.dump(schema).data
-        self._validate_schema(dumped)
-        assert dumped['properties']['myfield']['description'] == 'Brown Cow'
+def test_nested_descriptions():
+    class TestSchema(Schema):
+        myfield = fields.String(metadata={'description': 'Brown Cow'})
+        yourfield = fields.Integer(required=True)
+    class TestNestedSchema(Schema):
+        nested = fields.Nested(
+            TestSchema, metadata={'description': 'Nested 1', 'title': 'Title1'})
+        yourfield_nested = fields.Integer(required=True)
 
-    def test_one_of_validator(self):
-        schema = UserSchema()
-        json_schema = JSONSchema()
-        dumped = json_schema.dump(schema).data
-        self._validate_schema(dumped)
-        self.assertEqual(dumped['properties']['sex']['enum'],
-                         ['male', 'female'])
+    schema = TestNestedSchema()
+    json_schema = JSONSchema()
+    dumped = json_schema.dump(schema).data
+    _validate_schema(dumped)
+    nested_dmp = dumped['properties']['nested']
+    assert nested_dmp['properties']['myfield']['description'] == 'Brown Cow'
+    assert nested_dmp['description'] == 'Nested 1'
+    assert nested_dmp['title'] == 'Title1'
 
-    def test_range_validator(self):
-        schema = Address()
-        json_schema = JSONSchema()
-        dumped = json_schema.dump(schema).data
-        self._validate_schema(dumped)
-        self.assertEqual(dumped['properties']['floor']['minimum'], 1)
-        self.assertEqual(dumped['properties']['floor']['maximum'], 4)
 
-    def test_length_validator(self):
-        schema = UserSchema()
-        json_schema = JSONSchema()
-        dumped = json_schema.dump(schema).data
-        self._validate_schema(dumped)
-        self.assertEqual(dumped['properties']['name']['minLength'], 1)
-        self.assertEqual(dumped['properties']['name']['maxLength'], 255)
-        self.assertEqual(dumped['properties']['addresses']['minItems'], 1)
-        self.assertEqual(dumped['properties']['addresses']['maxItems'], 3)
-        self.assertEqual(dumped['properties']['const']['minLength'], 50)
-        self.assertEqual(dumped['properties']['const']['maxLength'], 50)
+def test_one_of_validator():
+    schema = UserSchema()
+    json_schema = JSONSchema()
+    dumped = json_schema.dump(schema).data
+    _validate_schema(dumped)
+    assert dumped['properties']['sex']['enum'] == ['male', 'female']
 
-    def test_title(self):
-        class TestSchema(Schema):
-            myfield = fields.String(metadata={'title': 'Brown Cowzz'})
-            yourfield = fields.Integer(required=True)
-        schema = TestSchema()
-        json_schema = JSONSchema()
-        dumped = json_schema.dump(schema).data
-        self._validate_schema(dumped)
-        self.assertEqual(dumped['properties']['myfield']['title'],
-                         'Brown Cowzz')
+def test_range_validator():
+    schema = Address()
+    json_schema = JSONSchema()
+    dumped = json_schema.dump(schema).data
+    _validate_schema(dumped)
+    assert dumped['properties']['floor']['minimum'] == 1
+    assert dumped['properties']['floor']['maximum'] == 4
 
-    def test_unknown_typed_field_throws_valueerror(self):
+def test_length_validator():
+    schema = UserSchema()
+    json_schema = JSONSchema()
+    dumped = json_schema.dump(schema).data
+    _validate_schema(dumped)
+    assert dumped['properties']['name']['minLength'] == 1
+    assert dumped['properties']['name']['maxLength'] == 255
+    assert dumped['properties']['addresses']['minItems'] == 1
+    assert dumped['properties']['addresses']['maxItems'] == 3
+    assert dumped['properties']['const']['minLength'] == 50
+    assert dumped['properties']['const']['maxLength'] == 50
 
-        class Invalid(fields.Field):
-            def _serialize(self, value, attr, obj):
-                return value
+def test_length_validator_value_error():
+    class BadSchema(Schema):
+        bob = fields.Integer(validate=validate.Length(min=1, max=3))
+    schema = BadSchema(strict=True)
+    json_schema = JSONSchema()
+    with pytest.raises(ValueError):
+        json_schema.dump(schema)
 
-        class UserSchema(Schema):
-            favourite_colour = Invalid()
 
-        schema = UserSchema()
-        json_schema = JSONSchema()
-        with self.assertRaises(ValueError):
-            json_schema.dump(schema).data
+def test_handle_range_not_number_returns_same_instance():
+    class SchemaWithStringRange(Schema):
+        floor = fields.String(validate=validate.Range(min=1, max=4))
+    class SchemaWithNoRange(Schema):
+        floor = fields.String()
+    class SchemaWithIntRangeValidate(Schema):
+        floor = fields.Integer(validate=validate.Range(min=1, max=4))
+    class SchemaWithIntRangeNoValidate(Schema):
+        floor = fields.Integer()
+    schema1 = SchemaWithStringRange(strict=True)
+    schema2 = SchemaWithNoRange(strict=True)
+    schema3 = SchemaWithIntRangeValidate(strict=True)
+    schema4 = SchemaWithIntRangeNoValidate(strict=True)
+    json_schema = JSONSchema()
+    json_schema.dump(schema1) == json_schema.dump(schema2)
+    json_schema.dump(schema3) != json_schema.dump(schema4)
 
-    def test_unknown_typed_field(self):
 
-        class Colour(fields.Field):
+def test_handle_range_no_minimum():
+    class SchemaMin(Schema):
+        floor = fields.Integer(validate=validate.Range(min=1, max=4))
+    class SchemaNoMin(Schema):
+        floor = fields.Integer(validate=validate.Range(max=4))
+    schema1 = SchemaMin(strict=True)
+    schema2 = SchemaNoMin(strict=True)
+    json_schema = JSONSchema()
+    dumped1 = json_schema.dump(schema1)
+    dumped2 = json_schema.dump(schema2)
+    dumped1.data['properties']['floor']['minimum'] == 1
+    dumped1.data['properties']['floor']['exclusiveMinimum'] is True
+    dumped2.data['properties']['floor']['minimum'] == 0
+    dumped2.data['properties']['floor']['exclusiveMinimum'] is False
 
-            def _jsonschema_type_mapping(self):
-                return {
-                    'type': 'string',
-                }
 
-            def _serialize(self, value, attr, obj):
-                r, g, b = value
-                r = hex(r)[2:]
-                g = hex(g)[2:]
-                b = hex(b)[2:]
-                return '#' + r + g + b
+def test_title():
+    class TestSchema(Schema):
+        myfield = fields.String(metadata={'title': 'Brown Cowzz'})
+        yourfield = fields.Integer(required=True)
+    schema = TestSchema()
+    json_schema = JSONSchema()
+    dumped = json_schema.dump(schema).data
+    _validate_schema(dumped)
+    assert dumped['properties']['myfield']['title'] == 'Brown Cowzz'
 
-        class UserSchema(Schema):
-            name = fields.String(required=True)
-            favourite_colour = Colour()
+def test_unknown_typed_field_throws_valueerror():
 
-        schema = UserSchema()
-        json_schema = JSONSchema()
-        dumped = json_schema.dump(schema).data
-        self.assertEqual(dumped['properties']['favourite_colour'],
-                         {'type': 'string'})
+    class Invalid(fields.Field):
+        def _serialize(self, value, attr, obj):
+            return value
+
+    class UserSchema(Schema):
+        favourite_colour = Invalid()
+
+    schema = UserSchema()
+    json_schema = JSONSchema()
+    with pytest.raises(ValueError):
+        json_schema.dump(schema).data
+
+def test_unknown_typed_field():
+
+    class Colour(fields.Field):
+
+        def _jsonschema_type_mapping(self):
+            return {
+                'type': 'string',
+            }
+
+        def _serialize(self, value, attr, obj):
+            r, g, b = value
+            r = hex(r)[2:]
+            g = hex(g)[2:]
+            b = hex(b)[2:]
+            return '#' + r + g + b
+
+    class UserSchema(Schema):
+        name = fields.String(required=True)
+        favourite_colour = Colour()
+
+    schema = UserSchema()
+    json_schema = JSONSchema()
+    dumped = json_schema.dump(schema).data
+    assert dumped['properties']['favourite_colour'] == {'type': 'string'}


### PR DESCRIPTION
I added a couple tests for a couple trivial things, then converted all the tests to pytest (since it's getting used anyways). Wonder if you could take a quick look then merge - then I think I can merge your pull request without coveralls complaining too, since this should actually bump us up to 100% coverage.

One thing I noticed is that your patch won't work with marshmallow 2.3, since one of the validators (Range? I can't remember) was breaking, so I bumped up the requirement to the most recent version of marshmallow. Let me know if you guys have any issues with that.
